### PR TITLE
Fix debug failure when there are files in src dir

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
@@ -79,6 +79,7 @@ class JDILauncher(
 	
 	private fun sourcesRootsOf(projectRoot: Path): Set<Path> = projectRoot.resolve("src")
 		.let(Files::list) // main, test
+		.filter { Files.isDirectory(it) }
 		.flatMap(Files::list) // kotlin, java
 		.filter { Files.isDirectory(it) }
 		.collect(Collectors.toSet())


### PR DESCRIPTION
This stops the debug session from crashing if there happen to be any files in the src directory.