### PR TITLE
* Fix Spring Boot project debugging bugs.

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
@@ -271,7 +271,8 @@ class KotlinDebugAdapter(
 			exceptionsPool.clear()
 			converter.variablesPool.clear()
 			converter.stackFramePool.removeAllOwnedBy(args.threadId)
-			(debuggee as JDIDebuggee).resumeVm()
+			// See the issue: https://github.com/fwcd/kotlin-debug-adapter/pull/40
+			debuggee?.resumeVm()
 		}
 		ContinueResponse().apply {
 			allThreadsContinued = false
@@ -354,6 +355,7 @@ class KotlinDebugAdapter(
 	override fun source(args: SourceArguments): CompletableFuture<SourceResponse> = notImplementedDAPMethod()
 	
 	override fun threads() = async.compute { onceDebuggeeIsPresent { debuggee ->
+		debuggee.updateThreads()
 		ThreadsResponse().apply {
 			threads = debuggee.threads
 				.asSequence()

--- a/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
@@ -32,6 +32,7 @@ import org.javacs.ktda.core.launch.AttachConfiguration
 import org.javacs.ktda.core.breakpoint.ExceptionBreakpoint
 import org.javacs.ktda.classpath.debugClassPathResolver
 import org.javacs.ktda.classpath.findValidKtFilePath
+import org.javacs.ktda.jdi.JDIDebuggee
 
 /** The debug server interface conforming to the Debug Adapter Protocol */
 class KotlinDebugAdapter(
@@ -270,6 +271,7 @@ class KotlinDebugAdapter(
 			exceptionsPool.clear()
 			converter.variablesPool.clear()
 			converter.stackFramePool.removeAllOwnedBy(args.threadId)
+			(debuggee as JDIDebuggee).resumeVm()
 		}
 		ContinueResponse().apply {
 			allThreadsContinued = false

--- a/adapter/src/main/kotlin/org/javacs/ktda/core/Debuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/Debuggee.kt
@@ -17,7 +17,11 @@ interface Debuggee {
 		get() = null
 	
 	fun exit()
-	
+
+	fun resumeVm()
+
+	fun updateThreads()
+
 	fun threadByID(id: Long): DebuggeeThread? = threads
 		.asSequence()
 		.filter { it.id == id }

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
@@ -129,8 +129,7 @@ class JDIDebuggee(
 			}
 			return request != null
 		} catch (e: AbsentInformationException) {
-			// Ignore exception.
-			return true
+			return false
 		}
 	}
 

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
@@ -20,6 +20,7 @@ import com.sun.jdi.VirtualMachine
 import com.sun.jdi.VMDisconnectedException
 import com.sun.jdi.event.ClassPrepareEvent
 import com.sun.jdi.request.EventRequest
+import com.sun.jdi.AbsentInformationException
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
@@ -117,18 +118,23 @@ class JDIDebuggee(
 	
 	/** Tries to set a breakpoint - Will return whether this was successful */
 	private fun setBreakpointAtType(refType: ReferenceType, lineNumber: Long): Boolean {
-		val location = refType
-			.locationsOfLine(lineNumber.toInt())
-			?.firstOrNull() ?: return false
-		val request = vm.eventRequestManager()
-			.createBreakpointRequest(location)
-		request?.let {
-			it.enable()
+		try {
+			val location = refType
+					.locationsOfLine(lineNumber.toInt())
+					?.firstOrNull() ?: return false
+			val request = vm.eventRequestManager()
+					.createBreakpointRequest(location)
+			request?.let {
+				it.enable()
+			}
+			return request != null
+		} catch (e: AbsentInformationException) {
+			// Ignore exception.
+			return true
 		}
-		return request != null
 	}
 
-	open fun resumeVm() {
+	fun resumeVm() {
 		vm.resume()
 	}
 	

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
@@ -54,7 +54,7 @@ class JDIDebuggee(
 		hookBreakpoints()
 	}
 	
-	private fun updateThreads() = threads.setAll(vm.allThreads().map { JDIThread(it, this) })
+	override fun updateThreads() = threads.setAll(vm.allThreads().map { JDIThread(it, this) })
 	
 	private fun hookBreakpoints() {
 		context.breakpointManager.also { manager ->
@@ -134,7 +134,7 @@ class JDIDebuggee(
 		}
 	}
 
-	fun resumeVm() {
+	override fun resumeVm() {
 		vm.resume()
 	}
 	

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
@@ -127,6 +127,10 @@ class JDIDebuggee(
 		}
 		return request != null
 	}
+
+	open fun resumeVm() {
+		vm.resume()
+	}
 	
 	override fun exit() {
 		LOG.info("Exiting JDI session")


### PR DESCRIPTION
Ｗhen I debug a Spring Boot program by attaching, I find a breakpoint works only once. If I run "continue," the breakpoint will not be hit again.

I refer to the code to fix this bug:
https://github.com/microsoft/java-debug/blob/27e3c455f8627ac895d49a5633409689e7fff6b4/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/DebugSession.java#L64 
I guess kotlin-debug-adapter misses a line to resume VM? I am not sure. Nevertheless, changes of my commit does fix this problem in my manual test. 🙂

Steps to reproduce the bug:
1. Run
```
git clone https://github.com/MrRogerHuang/SpringBootExample
cd SpringBootExample
./gradlew bootRun --debug-jvm
code .
```
2. Open src/main/kotlin/com/example/demo/DemoApplication.kt.
3. Set a breakpoint to this line:
https://github.com/MrRogerHuang/SpringBootExample/blob/e92ad942ddaf656c81d02ebd1026ab10d75693e5/src/main/kotlin/com/example/demo/DemoApplication.kt#L13
4. Run Kotlin Attach
4.1 (update) Detach the debugger and wait Spring Boot example run to a message line like:
`2020-06-29 13:57:01.030 INFO 42742 --- [ restartedMain] com.example.demo.DemoApplicationKt : Started DemoApplicationKt in 651.506 seconds (JVM running for 657.988)`
4.2 (update) Run Kotlin Attach again.
5. Open the URL by your browser: http://localhost:8080/hello You will find VS Code correctly hit the breakpoint.
6. Press Continue
7. Reload http://localhost:8080/hello again. You will find VS Code can't hit the breakpoint anymore ☹️