### PR TITLE
* Add a classpath root for Spring Boot searching for application.properties and templates.

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/classpath/ProjectClassesResolver.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/classpath/ProjectClassesResolver.kt
@@ -15,7 +15,9 @@ internal class ProjectClassesResolver(private val projectRoot: Path) : ClassPath
 			}
 		},
 		// Maven
-		sequenceOf(resolveIfExists(projectRoot, "target", "classes"))
+		sequenceOf(resolveIfExists(projectRoot, "target", "classes")),
+		// Spring Boot application.properties and templates.
+		sequenceOf(resolveIfExists(projectRoot, "build", "resources", "main"))
 	).flatten().filterNotNull().toSet()
 }
 


### PR DESCRIPTION
Spring Boot searches application.properties and templates by 4 kinds of paths:
1. A /config subdirectory of the current directory
2. The current directory
3. A classpath /config package
4. The classpath root

See: https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-application-property-files
After run `./gradlew build`, application.properties is copied from src/main/resources/application.properties to build/resources/main. Thus, I use the 4th method to let Spring Boot loads application.properties. Path build/resources/main is added as a classpath to kotlin-debug-adapter.

The modified kotlin-debug-adapter works well with debugging this Spring Boot example by "launch":
https://github.com/MrMYHuang/SpringBootExample/commit/146f864c755f8766df43f1a44141ee0853d9f194
It might also fix the issue #37.