### PR TITLE
Reuse variable references for better representation of cyclic references

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/core/scope/VariableTreeNode.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/scope/VariableTreeNode.kt
@@ -1,18 +1,18 @@
 package org.javacs.ktda.core.scope
 
+import org.javacs.ktda.util.Identifiable
+
 /**
  * A descriptor for a collection of child variables.
  * (usually a scope or a variable's fields)
  */
-interface VariableTreeNode {
+interface VariableTreeNode : Identifiable {
 	val name: String
 	val value: String?
 		get() = null
 	val type: String?
 		get() = null
 	val childs: List<VariableTreeNode>?
-		get() = null
-	val id: Long?
 		get() = null
 	
 	// TODO: Setters for values?

--- a/adapter/src/main/kotlin/org/javacs/ktda/core/scope/VariableTreeNode.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/scope/VariableTreeNode.kt
@@ -12,6 +12,8 @@ interface VariableTreeNode {
 		get() = null
 	val childs: List<VariableTreeNode>?
 		get() = null
+	val id: Long?
+		get() = null
 	
 	// TODO: Setters for values?
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/scope/JDIVariable.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/scope/JDIVariable.kt
@@ -11,7 +11,7 @@ import com.sun.jdi.Type
 
 class JDIVariable(
 	override val name: String,
-	jdiValue: Value?,
+	private val jdiValue: Value?,
 	jdiType: Type? = null
 ) : VariableTreeNode {
 	override val value: String = jdiValue?.toString() ?: "null" // TODO: Better string representation
@@ -35,4 +35,8 @@ class JDIVariable(
 		
 	private fun fieldsOf(jdiValue: ObjectReference, jdiType: ReferenceType) = jdiType.allFields()
 		.map { JDIVariable(it.name(), jdiValue.getValue(it), jdiType) }
+
+	override fun hashCode(): Int = (jdiValue?.hashCode() ?: 0) xor name.hashCode()
+
+	override fun equals(other: Any?): Boolean = other is JDIVariable && name == other.name && jdiValue == other.jdiValue
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/scope/JDIVariable.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/scope/JDIVariable.kt
@@ -17,6 +17,7 @@ class JDIVariable(
 	override val value: String = jdiValue?.toString() ?: "null" // TODO: Better string representation
 	override val type: String = (jdiType?.name() ?: jdiValue?.type()?.name()) ?: "Unknown type"
 	override val childs: List<VariableTreeNode>? by lazy { jdiValue?.let(::childrenOf) }
+	override val id: Long? = (jdiValue as? ObjectReference)?.uniqueID() ?: (jdiValue as? ArrayReference)?.uniqueID()
 	
 	private fun childrenOf(jdiValue: Value): List<VariableTreeNode> {
 		val jdiType = jdiValue.type()
@@ -35,8 +36,4 @@ class JDIVariable(
 		
 	private fun fieldsOf(jdiValue: ObjectReference, jdiType: ReferenceType) = jdiType.allFields()
 		.map { JDIVariable(it.name(), jdiValue.getValue(it), jdiType) }
-
-	override fun hashCode(): Int = (jdiValue?.hashCode() ?: 0) xor name.hashCode()
-
-	override fun equals(other: Any?): Boolean = other is JDIVariable && name == other.name && jdiValue == other.jdiValue
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/util/Identifiable.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/util/Identifiable.kt
@@ -1,0 +1,6 @@
+package org.javacs.ktda.util
+
+public interface Identifiable {
+    val id: Long?
+        get() = null
+}

--- a/adapter/src/main/kotlin/org/javacs/ktda/util/ObjectPool.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/util/ObjectPool.kt
@@ -32,6 +32,13 @@ class ObjectPool<O, V> {
 	
 	/** Stores an object and returns its (unique) id */
 	fun store(owner: O, value: V): Long {
+		// TODO: Perform this check more efficiently than in O(n),
+		//       perhaps add another mappings table?
+		val existingIDs = getIDsFor(owner, value)
+		if (existingIDs.isNotEmpty()) {
+			return existingIDs.first()
+		}
+
 		val id = currentID
 		val key = ObjectKey(id, owner)
 		val mapping = ObjectMapping(key, value)
@@ -74,4 +81,8 @@ class ObjectPool<O, V> {
 		.orEmpty()
 	
 	fun containsID(id: Long) = mappingsByID.contains(id)
+
+	private fun getIDsFor(owner: O, value: V): List<Long> = mappingsByID
+		.filter { it.value.key.owner == owner && it.value.value == value }
+		.map { it.key }
 }


### PR DESCRIPTION
Reuse variable references in object pools. This makes representation of cyclic references much more memory efficient, since every object only has to have a single ID.