### PR TITLE
Fix crashing issue because of exception when attaching tests

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/JDIDebuggee.kt
@@ -167,19 +167,22 @@ class JDIDebuggee(
 	override fun positionOf(location: Location): Position? = sourceOf(location)
 		?.let { Position(it, location.lineNumber()) }
 	
-	private fun sourceOf(location: Location): Source? {
-		val sourcePath = location.sourcePath()
-		val sourceName = location.sourceName()
-		
-		return sourcesRoots
-			.asSequence()
-			.map { it.resolve(sourcePath) }
-			.orEmpty()
-			.mapNotNull { findValidKtFilePath(it, sourceName) }
-			.firstOrNull()
-			?.let { Source(
-				name = sourceName ?: it.fileName.toString(),
-				filePath = it
-			) }
-	}
+    private fun sourceOf(location: Location): Source? =
+        try {
+            val sourcePath = location.sourcePath()
+            val sourceName = location.sourceName()
+
+            sourcesRoots
+                .asSequence()
+                .map { it.resolve(sourcePath) }
+                .orEmpty()
+                .mapNotNull { findValidKtFilePath(it, sourceName) }
+                .firstOrNull()
+                ?.let { Source(
+                    name = sourceName ?: it.fileName.toString(),
+                    filePath = it
+                ) }
+        } catch(exception: AbsentInformationException) {
+            null
+        }
 }


### PR DESCRIPTION
Like described in #59, the debug adapter crashes when attaching tests. This is because of a `AbsentInformationException` when trying to get positions of a breakpoint (due to the `Location` object not being able to resolve `sourcePath` and `sourceName`, and yes, I verified that it had issues with both). For now I have just made the method return null when we get that exception. I found no ways of finding the source file as of now, but I will continue looking for ways to do it. I still think making the debugger not crash is a good way forward for now.


Why merge this? While we won't get position information for breakpoints, we still get variable information for the breakpoint. This means the editor (tested with Emacs dap-mode) won't automatically jump to the source with the breakpoint, but will still show debug information like the variables for that breakpoint. You can also step in the code (without seeing where you are). While this is not perfect, it actually improves debugging tests by a tiny bit (making it possible to some minimal degree without crashing) 🙂  (there are no information on debugging tests as of now, and to my knowledge the attachment way is the only way for now)