### PR TITLE
Update lsp4j debug version to 0.15.0

### DIFF
--- a/adapter/build.gradle
+++ b/adapter/build.gradle
@@ -15,7 +15,7 @@ startScripts {
 
 dependencies {
 	// The JSON-RPC and Debug Adapter Protocol implementations
-	implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.12.0'
+	implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.15.0'
 	implementation 'org.jetbrains.kotlin:kotlin-stdlib'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
 	implementation('kotlin-language-server:shared') {

--- a/adapter/src/main/kotlin/org/javacs/ktda/adapter/DAPConverter.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/adapter/DAPConverter.kt
@@ -74,6 +74,12 @@ class DAPConverter(
 		line = lineConverter.toExternalLine(internalBreakpoint.position.lineNumber)
 		isVerified = true
 	}
+
+	fun toDAPBreakpoint(internalBreakpoint: InternalExceptionBreakpoint) = DAPBreakpoint().apply {
+		id = internalBreakpoint.id.toInt()
+		message = internalBreakpoint.label
+		isVerified = true
+	}
 	
 	fun toInternalStackFrame(frameId: Long) = stackFramePool.getByID(frameId)
 	


### PR DESCRIPTION
Upgrade to newest version of lsp4j debug library. 

runInTerminal was removed from the server interface, that is why it is removed here as well. setExceptionBreakpoints also has a return value now. You can read about that in the release notes for lsp4j version 0.13.0:
https://github.com/eclipse/lsp4j/releases/tag/v0.13.0