### PR TITLE
Include mavens test-classes folder to resolved project classpaths

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/classpath/ProjectClassesResolver.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/classpath/ProjectClassesResolver.kt
@@ -21,6 +21,7 @@ internal class ProjectClassesResolver(private val projectRoot: Path) : ClassPath
 		},
 		// Maven
 		sequenceOf(resolveIfExists(projectRoot, "target", "classes")),
+		sequenceOf(resolveIfExists(projectRoot, "target", "test-classes")),
 		// Spring Boot application.properties and templates.
 		sequenceOf(resolveIfExists(projectRoot, "build", "resources", "main"))
 	).flatten().filterNotNull().map(::ClassPathEntry).toSet()


### PR DESCRIPTION
# Allow maven test debugging

While working on a plugin setting up your debug-adapter for neovim I ran into some issues debugging tests.

Turns out while the `ProjectClassesResolver` does resolve a test directory for Gradle builds the test-classes folder used by maven seems to be left out.

Refrained from doing anything fancy to smooth things over. 
I was thinking that it might be nice to add something along the lines of `includeTestResourses` to the launch config next. As resolving the test folder does take a little bit of time you might want to save when debugging the main process. Don't you think?

Let me know what you think.