### PR TITLE
Upgrade Kotlin to 1.8.10 and Gradle to 7.5

### DIFF
--- a/adapter/src/test/resources/sample-workspace/gradle/wrapper/gradle-wrapper.properties
+++ b/adapter/src/test/resources/sample-workspace/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 projectVersion=0.4.2
-kotlinVersion=1.6.10
+kotlinVersion=1.8.10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Noticed in the failing build in #68 that it fails due to Kotlin Language Server (shared module) being upgraded to Kotlin 1.8.10. The older versions like 1.6 seems to have issues with dependencies that use newer versions of Kotlin. To fix this I suggest we upgrade the debug adapter right away 🙂 Let me know if you have any issues with this.