### PR TITLE
Set the kotlin-language-server shared version to a tag

### DIFF
--- a/adapter/build.gradle
+++ b/adapter/build.gradle
@@ -18,11 +18,7 @@ dependencies {
 	implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.15.0'
 	implementation 'org.jetbrains.kotlin:kotlin-stdlib'
 	implementation 'org.jetbrains.kotlin:kotlin-reflect'
-	implementation('kotlin-language-server:shared') {
-		version {
-			branch = 'main'
-		}
-	}
+	implementation('kotlin-language-server:shared:gradle_dsl_pre_platform')
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }


### PR DESCRIPTION
The current pipeline here, `kotlin-debug-adapter`, fails due to some changes in Kotlin language server. I created a new tag before the platform and plugin Gradle DSL changes. This should at least make the build here work for now, and also include the Kotlin 1.8.0 changes