### PR TITLE
Upgrade Actions versions and use non-deprecated release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         java: ['11', '17']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,34 +4,29 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+      
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Build distribution
         run: ./gradlew :adapter:distZip
       - name: Create release
-        uses: actions/create-release@v1
-        id: create_release
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Version ${{ github.ref }}
+          name: Version ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./adapter/build/distributions/adapter.zip
-          asset_name: adapter.zip
-          asset_content_type: application/zip
+          files: |
+            ./adapter/build/distributions/adapter.zip


### PR DESCRIPTION
When building or releasing/deploying, we get errors from Github Actions. Most of these are deprecation warnings for Node12 , but some are usage of deprecated methods in our actions. 


Also change the release action we are using. The old ones from Github are deprecated and no longer maintained. The new one is directly linked to from the repos of Githubs older actions. Hopefully it will behave 100 % the same.