### PR TITLE
support `cwd`, `env` and `envFile` parameters using sun jdi

### DIFF
--- a/adapter/build.gradle
+++ b/adapter/build.gradle
@@ -30,7 +30,6 @@ dependencies {
 	// The Java Debug Interface classes (com.sun.jdi.*)
 	implementation files("${System.properties['java.home']}/../lib/tools.jar")
 	// For CommandLineUtils.translateCommandLine
-	// https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils
 	implementation 'org.codehaus.plexus:plexus-utils:3.3.0'
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/adapter/build.gradle
+++ b/adapter/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	implementation 'com.github.fwcd.kotlin-language-server:shared:229c762a4d75304d21eba6d8e1231ed949247629'
 	// The Java Debug Interface classes (com.sun.jdi.*)
 	implementation files("${System.properties['java.home']}/../lib/tools.jar")
+	// For CommandLineUtils.translateCommandLine
+	// https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils
+	implementation 'org.codehaus.plexus:plexus-utils:3.3.0'
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
@@ -92,6 +92,8 @@ class KotlinDebugAdapter(
 	override fun launch(args: Map<String, Any>) = launcherAsync.execute {
 		performInitialization()
 
+		LOG.debug("launch args: $args")
+
 		val projectRoot = (args["projectRoot"] as? String)?.let { Paths.get(it) }
 			?: throw missingRequestArgument("launch", "projectRoot")
 
@@ -102,7 +104,9 @@ class KotlinDebugAdapter(
 
 		var cwd = (args["cwd"] as? String).let { if(it.isNullOrBlank()) projectRoot else Paths.get(it) }
 
-		var envs = args["envs"] as? List<String>
+		// Cast from com.google.gson.internal.LinkedTreeMap
+		@Suppress("UNCHECKED_CAST")
+		var envs = args["envs"] as? Map<String, String> ?: mapOf()
 
 		setupCommonInitializationParams(args)
 

--- a/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
@@ -100,13 +100,19 @@ class KotlinDebugAdapter(
 
 		val vmArguments = (args["vmArguments"] as? String) ?: ""
 
+		var cwd = (args["cwd"] as? String).let { if(it.isNullOrBlank()) projectRoot else Paths.get(it) }
+
+		var envs = args["envs"] as? List<String>
+
 		setupCommonInitializationParams(args)
 
 		val config = LaunchConfiguration(
 			debugClassPathResolver(listOf(projectRoot)).classpathOrEmpty,
 			mainClass,
 			projectRoot,
-			vmArguments
+			vmArguments,
+			cwd,
+			envs
 		)
 		debuggee = launcher.launch(
 			config,

--- a/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/adapter/KotlinDebugAdapter.kt
@@ -104,7 +104,7 @@ class KotlinDebugAdapter(
 
 		// Cast from com.google.gson.internal.LinkedTreeMap
 		@Suppress("UNCHECKED_CAST")
-		var envs = args["envs"] as? Map<String, String> ?: mapOf()
+		val env = args["env"] as? Map<String, String> ?: mapOf()
 
 		setupCommonInitializationParams(args)
 
@@ -114,7 +114,7 @@ class KotlinDebugAdapter(
 			projectRoot,
 			vmArguments,
 			cwd,
-			envs
+			env
 		)
 		debuggee = launcher.launch(
 			config,

--- a/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
@@ -6,5 +6,7 @@ class LaunchConfiguration(
 	val classpath: Set<Path>,
 	val mainClass: String,
 	val projectRoot: Path,
-	val vmArguments: String = ""
+	val vmArguments: String = "",
+	val cwd: Path = projectRoot,
+	val envs: Collection<String>? = null
 )

--- a/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
@@ -8,5 +8,5 @@ class LaunchConfiguration(
 	val projectRoot: Path,
 	val vmArguments: String = "",
 	val cwd: Path = projectRoot,
-	val envs: Collection<String>? = null
+	val envs: Map<String, String> = mapOf()
 )

--- a/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/core/launch/LaunchConfiguration.kt
@@ -8,5 +8,5 @@ class LaunchConfiguration(
 	val projectRoot: Path,
 	val vmArguments: String = "",
 	val cwd: Path = projectRoot,
-	val envs: Map<String, String> = mapOf()
+	val env: Map<String, String> = mapOf()
 )

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
@@ -4,7 +4,6 @@ import org.javacs.kt.LOG
 import org.javacs.ktda.core.launch.DebugLauncher
 import org.javacs.ktda.core.launch.LaunchConfiguration
 import org.javacs.ktda.core.launch.AttachConfiguration
-import org.javacs.ktda.core.Debuggee
 import org.javacs.ktda.core.DebugContext
 import org.javacs.ktda.util.KotlinDAException
 import org.javacs.ktda.jdi.JDIDebuggee
@@ -16,14 +15,11 @@ import com.sun.jdi.connect.AttachingConnector
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Files
-import java.net.URLEncoder
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 import java.util.stream.Collectors
+import org.javacs.kt.LOG
 
 class JDILauncher(
 	private val attachTimeout: Int = 50,
-	private val vmArguments: String? = null,
 	private val modulePaths: String? = null
 ) : DebugLauncher {
 	private val vmManager: VirtualMachineManager
@@ -57,6 +53,8 @@ class JDILauncher(
 			args["suspend"]!!.setValue("true")
 			args["options"]!!.setValue(formatOptions(config))
 			args["main"]!!.setValue(formatMainClass(config))
+			args["cwd"]!!.setValue(config.cwd.toAbsolutePath().toString())
+			args["envs"]!!.setValue(KDACommandLineLauncher.urlEncode(config.envs) ?: "")
 		}
 	
 	private fun createAttachArgs(config: AttachConfiguration, connector: Connector): Map<String, Connector.Argument> = connector.defaultArguments()
@@ -71,8 +69,8 @@ class JDILauncher(
 		?: throw KotlinDAException("Could not find an attaching connector (for a new debuggee VM)")
 	
 	private fun createLaunchConnector(): LaunchingConnector = vmManager.launchingConnectors()
-		// Workaround for JDK 11+ where the first launcher (RawCommandLineLauncher) does not properly support args
-		.let { it.find { it.javaClass.name == "com.sun.tools.jdi.SunCommandLineLauncher" } ?: it.firstOrNull() }
+		// Using our own connector to support cwd and envs
+		.let { it.find { it.name().equals(KDACommandLineLauncher::class.java.name) } ?: it.firstOrNull() }
 		?: throw KotlinDAException("Could not find a launching connector (for a new debuggee VM)")
 	
 	private fun sourcesRootsOf(projectRoot: Path): Set<Path> = projectRoot.resolve("src")
@@ -100,13 +98,5 @@ class JDILauncher(
 	private fun formatClasspath(config: LaunchConfiguration): String = config.classpath
 		.map { it.toAbsolutePath().toString() }
 		.reduce { prev, next -> "$prev${File.pathSeparatorChar}$next" }
-		
-	private fun urlEncode(arg: Collection<String>?) = arg
-		?.map { URLEncoder.encode(it, StandardCharsets.UTF_8.name()) }
-		?.reduce { a, b -> "$a\n$b" }
-		
-	private fun urlDecode(arg: String?) = arg
-		?.split("\n")
-		?.map { URLDecoder.decode(it, StandardCharsets.UTF_8.name()) }
-		?.toList()
+
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
@@ -54,7 +54,7 @@ class JDILauncher(
 			args["options"]!!.setValue(formatOptions(config))
 			args["main"]!!.setValue(formatMainClass(config))
 			args["cwd"]!!.setValue(config.cwd.toAbsolutePath().toString())
-			args["envs"]!!.setValue(KDACommandLineLauncher.urlEncode(config.envs) ?: "")
+			args["envs"]!!.setValue(KDACommandLineLauncher.urlEncode(config.envs.map { "${it.key}=${it.value}" }) ?: "")
 		}
 	
 	private fun createAttachArgs(config: AttachConfiguration, connector: Connector): Map<String, Connector.Argument> = connector.defaultArguments()
@@ -68,7 +68,7 @@ class JDILauncher(
 		.let { it.find { it.name() == "com.sun.jdi.SocketAttach" } ?: it.firstOrNull() }
 		?: throw KotlinDAException("Could not find an attaching connector (for a new debuggee VM)")
 	
-	private fun createLaunchConnector(): LaunchingConnector = vmManager.launchingConnectors().also { LOG.info("connectors: $it") }
+	private fun createLaunchConnector(): LaunchingConnector = vmManager.launchingConnectors().also { LOG.debug("connectors: $it") }
 		// Using our own connector to support cwd and envs
 		.let { it.find { it.name() == KDACommandLineLauncher::class.java.name } ?: it.firstOrNull() }
 		?: throw KotlinDAException("Could not find a launching connector (for a new debuggee VM)")

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/JDILauncher.kt
@@ -68,9 +68,9 @@ class JDILauncher(
 		.let { it.find { it.name() == "com.sun.jdi.SocketAttach" } ?: it.firstOrNull() }
 		?: throw KotlinDAException("Could not find an attaching connector (for a new debuggee VM)")
 	
-	private fun createLaunchConnector(): LaunchingConnector = vmManager.launchingConnectors()
+	private fun createLaunchConnector(): LaunchingConnector = vmManager.launchingConnectors().also { LOG.info("connectors: $it") }
 		// Using our own connector to support cwd and envs
-		.let { it.find { it.name().equals(KDACommandLineLauncher::class.java.name) } ?: it.firstOrNull() }
+		.let { it.find { it.name() == KDACommandLineLauncher::class.java.name } ?: it.firstOrNull() }
 		?: throw KotlinDAException("Could not find a launching connector (for a new debuggee VM)")
 	
 	private fun sourcesRootsOf(projectRoot: Path): Set<Path> = projectRoot.resolve("src")

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
@@ -1,0 +1,194 @@
+package org.javacs.ktda.jdi.launch
+
+import com.sun.jdi.Bootstrap
+import com.sun.jdi.VirtualMachine
+import com.sun.jdi.connect.Connector
+import com.sun.jdi.connect.IllegalConnectorArgumentsException
+import com.sun.jdi.connect.Transport
+import com.sun.jdi.connect.VMStartException
+import com.sun.jdi.connect.spi.Connection
+import com.sun.jdi.connect.spi.TransportService
+import com.sun.tools.jdi.SocketTransportService
+import com.sun.tools.jdi.SunCommandLineLauncher
+import org.codehaus.plexus.util.cli.CommandLineUtils
+import org.javacs.kt.LOG
+import java.io.File
+import java.io.IOException
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+internal const val ARG_HOME = "home"
+internal const val ARG_OPTIONS = "options"
+internal const val ARG_MAIN = "main"
+internal const val ARG_SUSPEND = "suspend"
+internal const val ARG_QUOTE = "quote"
+internal const val ARG_VM_EXEC = "vmexec"
+internal const val ARG_CWD = "cwd"
+internal const val ARG_ENVS = "envs"
+
+/**
+ * A custom LaunchingConnector that supports cwd and env variables
+ */
+open class KDACommandLineLauncher : SunCommandLineLauncher {
+
+    protected val defaultArguments = mutableMapOf<String, Connector.Argument>()
+
+    /**
+     * We only support SocketTransportService
+     */
+    protected val transportService = SocketTransportService()
+    protected val transport = Transport { "dt_socket" }
+
+    companion object {
+
+        fun urlEncode(arg: Collection<String>?) = arg
+                ?.map { URLEncoder.encode(it, StandardCharsets.UTF_8.name()) }
+                ?.fold("") { a, b -> "$a\n$b" }
+
+        fun urlDecode(arg: String?) = arg
+                ?.trim('\n')
+                ?.split("\n")
+                ?.map { URLDecoder.decode(it, StandardCharsets.UTF_8.name()) }
+                ?.toList()
+    }
+
+    constructor() : super() {
+
+        defaultArguments.putAll(super.defaultArguments())
+
+        defaultArguments[ARG_CWD] = StringArgument(
+                name = ARG_CWD,
+                description = "Current working directory")
+
+        defaultArguments[ARG_ENVS] = StringArgument(
+                name = ARG_ENVS,
+                description = "Environment variables")
+    }
+
+    override fun name(): String {
+        return this.javaClass.name
+    }
+
+    override fun description(): String {
+        return "A custom launcher supporting cwd and env variables"
+    }
+
+    override fun defaultArguments(): Map<String, Connector.Argument> {
+        return this.defaultArguments
+    }
+
+    override fun toString(): String {
+        return name()
+    }
+
+    protected fun getOrDefault(arguments: Map<String, Connector.Argument>, argName: String): String {
+        return arguments[argName]?.value() ?: defaultArguments[argName]?.value() ?: ""
+    }
+
+    /**
+     * A customized method to launch the vm and connect to it, supporting cwd and env variables
+     */
+    @Throws(IOException::class, IllegalConnectorArgumentsException::class, VMStartException::class)
+    override fun launch(arguments: Map<String, Connector.Argument>): VirtualMachine {
+        val vm: VirtualMachine
+
+        val home = getOrDefault(arguments, ARG_HOME)
+        val options = getOrDefault(arguments, ARG_OPTIONS)
+        val main = getOrDefault(arguments, ARG_MAIN)
+        val suspend = getOrDefault(arguments, ARG_SUSPEND).toBoolean()
+        val quote = getOrDefault(arguments, ARG_QUOTE)
+        var exe = getOrDefault(arguments, ARG_VM_EXEC)
+        val cwd = getOrDefault(arguments, ARG_CWD)
+        val envs = urlDecode(getOrDefault(arguments, ARG_ENVS))?.toTypedArray()
+
+        check(quote.length == 1) {"Invalid length for $ARG_QUOTE: $quote"}
+        check(!options.contains("-Djava.compiler=") ||
+                options.toLowerCase().contains("-djava.compiler=none")) { "Cannot debug with a JIT compiler. $ARG_OPTIONS: $options"}
+
+        val listenKey = transportService.startListening()
+        val address = listenKey.address()
+
+        try {
+            val command = StringBuilder()
+
+            exe = if (home.isNotEmpty()) Paths.get(home, "bin", exe).toString() else exe
+            command.append(wrapWhitespace(exe))
+
+            command.append(" $options")
+
+            //debug options
+            command.append(" -agentlib:jdwp=transport=${transport.name()},address=$address,server=n,suspend=${if (suspend) 'y' else 'n'}")
+
+            command.append(" $main")
+
+            LOG.debug("command before tokenize: $command")
+
+            vm = launch(commandArray = CommandLineUtils.translateCommandline(command.toString()), listenKey = listenKey,
+                    ts = transportService, cwd = cwd, envs = envs
+            )
+
+        } finally {
+            transportService.stopListening(listenKey)
+        }
+        return vm
+    }
+
+    internal fun wrapWhitespace(str: String): String {
+       return if(str.contains(' ')) "\"$str\" " else str
+    }
+
+    @Throws(IOException::class, VMStartException::class)
+    fun launch(commandArray: Array<String>,
+                        listenKey: TransportService.ListenKey,
+                        ts: TransportService, cwd: String, envs: Array<String>? = null): VirtualMachine {
+
+        val (connection, process) = launchAndConnect(commandArray, listenKey, ts, cwd = cwd, envs = envs)
+
+        return Bootstrap.virtualMachineManager().createVirtualMachine(connection,
+                process)
+    }
+
+
+    /**
+     * launch the command, connect to transportService, and returns the connection / process pair
+     */
+    protected fun launchAndConnect(commandArray: Array<String>, listenKey: TransportService.ListenKey,
+                         ts: TransportService, cwd: String = "", envs: Array<String>? = null): Pair<Connection, Process>{
+
+        val dir = if(cwd.isNotBlank() && Files.isDirectory(Paths.get(cwd))) File(cwd) else null
+
+        var threadCount = 0
+
+        val executors = Executors.newFixedThreadPool(2) { Thread(it, "${this.javaClass.simpleName}-${threadCount++}") }
+        val process = Runtime.getRuntime().exec(commandArray, envs, dir)
+
+        val connectionTask: Callable<Any> = Callable { ts.accept(listenKey, 0,0).also { LOG.debug("ts.accept invoked") } }
+        val exitCodeTask: Callable<Any> = Callable { process.waitFor().also { LOG.debug("process.waitFor invoked") } }
+
+        try {
+            when (val result = executors.invokeAny(listOf(connectionTask, exitCodeTask))) {
+                // successfully connected to transport service
+                is Connection -> return Pair(result, process)
+
+                // cmd exited before connection. some thing wrong
+                is Int -> throw VMStartException(
+                        "VM initialization failed. exit code: ${process?.exitValue()}, cmd: $commandArray", process)
+
+                // should never occur
+                else -> throw IllegalStateException("Unknown result: $result")
+            }
+        } finally {
+            // release the executors. no longer needed.
+            executors.shutdown()
+            executors.awaitTermination(1, TimeUnit.SECONDS)
+        }
+
+    }
+
+}

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
@@ -5,10 +5,9 @@ import com.sun.jdi.VirtualMachine
 import com.sun.jdi.connect.*
 import com.sun.jdi.connect.spi.Connection
 import com.sun.jdi.connect.spi.TransportService
-import org.codehaus.plexus.util.cli.CommandLineUtils
-import org.javacs.kt.LOG
 import java.io.File
 import java.io.IOException
+import java.io.InputStream
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -16,8 +15,10 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.*
 import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import org.javacs.kt.LOG
 
 internal const val ARG_HOME = "home"
 internal const val ARG_OPTIONS = "options"
@@ -28,18 +29,14 @@ internal const val ARG_VM_EXEC = "vmexec"
 internal const val ARG_CWD = "cwd"
 internal const val ARG_ENV = "env"
 
-/**
- * A custom LaunchingConnector that supports cwd and env variables
- */
+/** A custom LaunchingConnector that supports cwd and env variables */
 open class KDACommandLineLauncher : LaunchingConnector {
 
     protected val defaultArguments = mutableMapOf<String, Connector.Argument>()
 
-    /**
-     * We only support SocketTransportService
-     */
-    protected var transportService : TransportService? = null
-    protected var transport = Transport { "dt_socket" }
+    /** We only support SocketTransportService */
+    protected val transportService: TransportService
+    protected val transport = Transport { "dt_socket" }
 
     companion object {
 
@@ -55,226 +52,231 @@ open class KDACommandLineLauncher : LaunchingConnector {
     }
 
     constructor() : super() {
-
-        defaultArguments[ARG_HOME] = StringArgument(ARG_HOME, description = "Java home", value = System.getProperty("java.home"))
-
-        defaultArguments[ARG_OPTIONS] = StringArgument(ARG_OPTIONS, description = "Jvm arguments")
-
-        defaultArguments[ARG_MAIN] = StringArgument(ARG_MAIN, description = "Main class name and parameters", mustSpecify = true)
-
-        defaultArguments[ARG_SUSPEND] = StringArgument(ARG_SUSPEND, description = "Whether launch the debugee in suspend mode", value = "true")
-
-        defaultArguments[ARG_QUOTE] = StringArgument(ARG_QUOTE, description = "Quote char", value = "\"")
-
-        defaultArguments[ARG_VM_EXEC] = StringArgument(ARG_VM_EXEC, description = "The java exec", value = "java")
-
-        defaultArguments[ARG_CWD] = StringArgument(ARG_CWD, description = "Current working directory")
-
-        defaultArguments[ARG_ENVS] = StringArgument(ARG_ENVS, description = "Environment variables")
-
-        // Load TransportService 's implementation
-        transportService = Class.forName("com.sun.tools.jdi.SocketTransportService").getDeclaredConstructor().newInstance() as TransportService
-
-        if(transportService == null){
-            throw IllegalStateException("Failed to load com.sun.tools.jdi.SocketTransportService")
+        defaultArguments.apply {
+            set(ARG_HOME, StringArgument(ARG_HOME, "Java home", value = System.getProperty("java.home")))
+            set(ARG_OPTIONS, StringArgument(ARG_OPTIONS, "Jvm arguments"))
+            set(ARG_MAIN, StringArgument(ARG_MAIN, "Main class name and parameters", mustSpecify = true))
+            set(ARG_SUSPEND, StringArgument(ARG_SUSPEND, "Whether launch the debugee in suspend mode", "true"))
+            set(ARG_QUOTE, StringArgument(ARG_QUOTE, "Quote char", value = "\""))
+            set(ARG_VM_EXEC, StringArgument(ARG_VM_EXEC, "The java exec", value = "java"))
+            set(ARG_CWD, StringArgument(ARG_CWD, "Current working directory"))
+            set(ARG_ENV, StringArgument(ARG_ENV, "Environment variables"))
         }
 
+        // Load TransportService 's implementation
+        try {
+            transportService =
+                    Class.forName("com.sun.tools.jdi.SocketTransportService")
+                            .getDeclaredConstructor()
+                            .newInstance() as
+                            TransportService
+        } catch (e: Exception) {
+            throw IllegalStateException("Failed to load com.sun.tools.jdi.SocketTransportService")
+        }
     }
 
-    override fun name(): String {
-        return this.javaClass.name
-    }
+    override fun name(): String = javaClass.name
 
-    override fun description(): String {
-        return "A custom launcher supporting cwd and env variables"
-    }
+    override fun description(): String = "A custom launcher supporting cwd and env variables"
 
-    override fun defaultArguments(): Map<String, Connector.Argument> {
-        return this.defaultArguments
-    }
+    override fun defaultArguments(): Map<String, Connector.Argument> = defaultArguments
 
-    override fun toString(): String {
-        return name()
-    }
+    override fun toString(): String = name()
 
-    override fun transport(): Transport {
-        return transport
-    }
+    override fun transport(): Transport = transport
 
-    protected fun getOrDefault(arguments: Map<String, Connector.Argument>, argName: String): String {
+    protected fun getOrDefault(
+        arguments: Map<String, Connector.Argument>,
+        argName: String
+    ): String {
         return arguments[argName]?.value() ?: defaultArguments[argName]?.value() ?: ""
     }
 
-    protected fun translateCommandline(toProcess: String): Array<String> {
-        if (toProcess.length == 0 ) return emptyArray()
-
-        // parse with a simple finite state machine
-        val normal = 0;
-        val inQuote = 1;
-        val inDoubleQuote = 2;
-        var state = normal;
-
-        val tok = StringTokenizer( toProcess, "\"\' ", true );
-        var v = mutableListOf<String>();
-        val current = StringBuilder();
-
-        while ( tok.hasMoreTokens() ) {
-            val nextTok = tok.nextToken();
-            when ( state ) {
-                inQuote -> {
-                    if ( "\'".equals( nextTok ) )
-                    {
-                        state = normal;
-                    }
-                    else
-                    {
-                        current.append( nextTok );
-                    }
-                }
-                inDoubleQuote -> {
-                    if ( "\"".equals( nextTok ) )
-                    {
-                        state = normal;
-                    }
-                    else
-                    {
-                        current.append( nextTok );
-                    }
-                }
-                else -> {
-                    if ( "\'".equals( nextTok ) )
-                    {
-                        state = inQuote;
-                    }
-                    else if ( "\"".equals( nextTok ) )
-                    {
-                        state = inDoubleQuote;
-                    }
-                    else if ( " ".equals( nextTok ) )
-                    {
-                        if ( current.length != 0 )
-                        {
-                            v.add( current.toString() );
-                            current.setLength( 0 );
-                        }
-                    }
-                    else
-                    {
-                        current.append( nextTok );
-                    }
-                    break;
+    private fun tokenizeCommandLine(args: String): Array<String> {
+        val result = mutableListOf<String>()
+    
+        val DEFAULT = 0
+        val ARG = 1
+        val IN_DOUBLE_QUOTE = 2
+        val IN_SINGLE_QUOTE = 3
+    
+        var state = DEFAULT
+        val buf = StringBuilder()
+        val len = args.length
+        var i = 0
+    
+        while (i < len) {
+            var ch = args[i]
+            if (ch.isWhitespace()) {
+                if (state == DEFAULT) {
+                    // skip
+                    i++
+                    continue
+                } else if (state == ARG) {
+                    state = DEFAULT
+                    result.add(buf.toString())
+                    buf.setLength(0)
+                    i++
+                    continue
                 }
             }
+            when (state) {
+                DEFAULT, ARG -> {
+                    when {
+                        ch == '"' -> state = IN_DOUBLE_QUOTE
+                        ch == '\'' -> state = IN_SINGLE_QUOTE
+                        ch == '\\' && i + 1 < len -> {
+                            state = ARG
+                            ch = args[++i]
+                            buf.append(ch)
+                        }
+                        else -> {
+                            state = ARG
+                            buf.append(ch)
+                        }
+                    }
+                }
+                IN_DOUBLE_QUOTE -> {
+                    when {
+                        ch == '"' -> state = ARG
+                        ch == '\\' && i + 1 < len && (args[i + 1] == '\\' || args[i + 1] == '"') -> {
+                            ch = args[++i]
+                            buf.append(ch)
+                        }
+                        else -> buf.append(ch)
+                    }
+                }
+                IN_SINGLE_QUOTE -> {
+                    if (ch == '\'') {
+                        state = ARG
+                    } else {
+                        buf.append(ch)
+                    }
+                }
+                else -> throw IllegalStateException()
+            }
+            i++
         }
-
-        if (current.length != 0) v.add( current.toString() )
-
-        if ( ( state == inQuote ) || ( state == inDoubleQuote ) )
-        {
-            throw Exception( "unbalanced quotes in " + toProcess );
+        if (buf.isNotEmpty() || state != DEFAULT) {
+            result.add(buf.toString())
         }
-
-        return v.toTypedArray()
+    
+        return result.toTypedArray()
     }
 
-    /**
-     * A customized method to launch the vm and connect to it, supporting cwd and env variables
-     */
-    @Throws(IOException::class, IllegalConnectorArgumentsException::class, VMStartException::class)
-    override fun launch(arguments: Map<String, Connector.Argument>): VirtualMachine {
-        val vm: VirtualMachine
-
+    private fun buildCommandLine(arguments: Map<String, Connector.Argument>, address: String): String {
         val home = getOrDefault(arguments, ARG_HOME)
+        val javaExe = getOrDefault(arguments, ARG_VM_EXEC)
         val options = getOrDefault(arguments, ARG_OPTIONS)
-        val main = getOrDefault(arguments, ARG_MAIN)
         val suspend = getOrDefault(arguments, ARG_SUSPEND).toBoolean()
-        val quote = getOrDefault(arguments, ARG_QUOTE)
-        var exe = getOrDefault(arguments, ARG_VM_EXEC)
-        val cwd = getOrDefault(arguments, ARG_CWD)
-        val envs = urlDecode(getOrDefault(arguments, ARG_ENVS))?.toTypedArray()
+        val main = getOrDefault(arguments, ARG_MAIN)
+        
+        val exe = if (home.isNotEmpty()) Paths.get(home, "bin", javaExe).toString() else javaExe
 
-        check(quote.length == 1) {"Invalid length for $ARG_QUOTE: $quote"}
-        check(!options.contains("-Djava.compiler=") ||
-                options.toLowerCase().contains("-djava.compiler=none")) { "Cannot debug with a JIT compiler. $ARG_OPTIONS: $options"}
-
-        val listenKey = transportService?.startListening() ?: throw IllegalStateException("Failed to do transportService.startListening()")
-        val address = listenKey.address()
-
-        try {
-            val command = StringBuilder()
-
-            exe = if (home.isNotEmpty()) Paths.get(home, "bin", exe).toString() else exe
-            command.append(wrapWhitespace(exe))
-
-            command.append(" $options")
-
-            //debug options
-            command.append(" -agentlib:jdwp=transport=${transport.name()},address=$address,server=n,suspend=${if (suspend) 'y' else 'n'}")
-
-            command.append(" $main")
-
-            LOG.debug("command before tokenize: $command")
-
-            vm = launch(commandArray = this.translateCommandline(command.toString()), listenKey = listenKey,
-                    ts = transportService!!, cwd = cwd, envs = envs
+        return StringBuilder().apply {
+            append("$exe")
+            val jdwpLine = arrayOf(
+                "transport=${transport.name()}",
+                "address=$address",
+                "server=n",
+                "suspend=${if (suspend) 'y' else 'n'}"
             )
+            append(" -agentlib:jdwp=${jdwpLine.joinToString(",")}")
+            append(" $options")
+            append(" $main")
+        }.toString()
+    }
 
-        } finally {
-            transportService?.stopListening(listenKey)
+    /** A customized method to launch the vm and connect to it, supporting cwd and env variables */
+    @Throws(IOException::class, IllegalConnectorArgumentsException::class, VMStartException::class)
+    override fun launch(arguments: Map<String, Connector.Argument>): VirtualMachine {        
+        val quote = getOrDefault(arguments, ARG_QUOTE)
+        val options = getOrDefault(arguments, ARG_OPTIONS)
+        val cwd = getOrDefault(arguments, ARG_CWD)
+        val env = urlDecode(getOrDefault(arguments, ARG_ENV))?.toTypedArray()
+
+        check(quote.length == 1) { "Invalid length for $ARG_QUOTE: $quote" }
+        check(!options.contains("-Djava.compiler=") || options.lowercase().contains("-djava.compiler=none")) {
+            "Cannot debug with a JIT compiler. $ARG_OPTIONS: $options" 
         }
-        return vm
+
+        val listenKey = transportService.startListening()
+        ?: throw IllegalStateException("Failed to do transportService.startListening()")
+
+        val command = buildCommandLine(arguments, listenKey.address())
+        val tokenizedCommand = tokenizeCommandLine(command)
+
+        val (connection, process) = launchAndConnect(tokenizedCommand, listenKey, transportService, cwd, env)
+        return Bootstrap.virtualMachineManager().createVirtualMachine(connection, process)
     }
 
-    internal fun wrapWhitespace(str: String): String {
-       return if(str.contains(' ')) "\"$str\" " else str
+    private fun streamToString(stream: InputStream): String {
+        val lineSep = System.getProperty("line.separator")
+        return StringBuilder().apply {
+            var line: String?
+            val reader = stream.bufferedReader()
+
+            while (reader.readLine().also { line = it } != null) {
+                append(line)
+                append(lineSep)
+            }
+        }.toString()
     }
-
-    @Throws(IOException::class, VMStartException::class)
-    fun launch(commandArray: Array<String>,
-                        listenKey: TransportService.ListenKey,
-                        ts: TransportService, cwd: String, envs: Array<String>? = null): VirtualMachine {
-
-        val (connection, process) = launchAndConnect(commandArray, listenKey, ts, cwd = cwd, envs = envs)
-
-        return Bootstrap.virtualMachineManager().createVirtualMachine(connection,
-                process)
-    }
-
 
     /**
      * launch the command, connect to transportService, and returns the connection / process pair
      */
-    protected fun launchAndConnect(commandArray: Array<String>, listenKey: TransportService.ListenKey,
-                         ts: TransportService, cwd: String = "", envs: Array<String>? = null): Pair<Connection, Process>{
+    protected fun launchAndConnect(
+            commandArray: Array<String>,
+            listenKey: TransportService.ListenKey,
+            ts: TransportService,
+            cwd: String = "",
+            envs: Array<String>? = null
+    ): Pair<Connection, Process> {
 
-        val dir = if(cwd.isNotBlank() && Files.isDirectory(Paths.get(cwd))) File(cwd) else null
+        val dir = if (cwd.isNotBlank() && Files.isDirectory(Paths.get(cwd))) File(cwd) else null
 
-        var threadCount = 0
-
-        val executors = Executors.newFixedThreadPool(2) { Thread(it, "${this.javaClass.simpleName}-${threadCount++}") }
         val process = Runtime.getRuntime().exec(commandArray, envs, dir)
 
-        val connectionTask: Callable<Any> = Callable { ts.accept(listenKey, 0,0).also { LOG.debug("ts.accept invoked") } }
-        val exitCodeTask: Callable<Any> = Callable { process.waitFor().also { LOG.debug("process.waitFor invoked") } }
+        val result = CompletableFuture<Pair<Connection, Process>>()
 
-        try {
-            when (val result = executors.invokeAny(listOf(connectionTask, exitCodeTask))) {
-                // successfully connected to transport service
-                is Connection -> return Pair(result, process)
+        process.onExit().thenAcceptAsync() { pr ->
+            if (result.isDone) return@thenAcceptAsync
 
-                // cmd exited before connection. some thing wrong
-                is Int -> throw VMStartException(
-                        "VM initialization failed. exit code: ${process?.exitValue()}, cmd: $commandArray", process)
+            val exitCode = pr.exitValue()
+            val stdOut = streamToString(process.inputStream)
+            val stdErr = streamToString(process.errorStream)
 
-                // should never occur
-                else -> throw IllegalStateException("Unknown result: $result")
-            }
-        } finally {
-            // release the executors. no longer needed.
-            executors.shutdown()
-            executors.awaitTermination(1, TimeUnit.SECONDS)
+            LOG.error("Process exited with status: ${exitCode} \n $stdOut \n $stdErr")
+            result.completeExceptionally(VMStartException("Process exited with status: ${exitCode}", process))
+
+            try {
+                ts.stopListening(listenKey)
+            } catch (e: Exception) {}
         }
 
-    }
+        CompletableFuture.runAsync() {
+            try {
+                val vm = ts.accept(listenKey, 5_000, 5_000)
+                result.complete(Pair(vm, process))
+            } catch (e: IllegalConnectorArgumentsException) {
+                result.completeExceptionally(e)
+            } catch (e: IOException) {
+                if (result.isDone) return@runAsync
 
+                val stdOut = streamToString(process.inputStream)
+                val stdErr = streamToString(process.errorStream)
+
+                LOG.error("Failed to connect to the launched process: \n $stdOut \n $stdErr")
+
+                process.destroy()
+
+                result.completeExceptionally(e)
+            } catch (e: RuntimeException) {
+                result.completeExceptionally(e)
+            }
+        }
+
+        return result.get()
+    }
 }

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
@@ -26,7 +26,7 @@ internal const val ARG_SUSPEND = "suspend"
 internal const val ARG_QUOTE = "quote"
 internal const val ARG_VM_EXEC = "vmexec"
 internal const val ARG_CWD = "cwd"
-internal const val ARG_ENVS = "envs"
+internal const val ARG_ENV = "env"
 
 /**
  * A custom LaunchingConnector that supports cwd and env variables

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncher.kt
@@ -56,7 +56,7 @@ open class KDACommandLineLauncher : LaunchingConnector {
             set(ARG_HOME, StringArgument(ARG_HOME, "Java home", value = System.getProperty("java.home")))
             set(ARG_OPTIONS, StringArgument(ARG_OPTIONS, "Jvm arguments"))
             set(ARG_MAIN, StringArgument(ARG_MAIN, "Main class name and parameters", mustSpecify = true))
-            set(ARG_SUSPEND, StringArgument(ARG_SUSPEND, "Whether launch the debugee in suspend mode", "true"))
+            set(ARG_SUSPEND, StringArgument(ARG_SUSPEND, "Whether launch the debugee in suspend mode", value = "true"))
             set(ARG_QUOTE, StringArgument(ARG_QUOTE, "Quote char", value = "\""))
             set(ARG_VM_EXEC, StringArgument(ARG_VM_EXEC, "The java exec", value = "java"))
             set(ARG_CWD, StringArgument(ARG_CWD, "Current working directory"))

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/StringArgument.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/launch/StringArgument.kt
@@ -1,0 +1,43 @@
+package org.javacs.ktda.jdi.launch
+
+import com.sun.jdi.connect.Connector
+
+/**
+ * An implementation to Connector.Argument, used for arguments to launch a LaunchingConnector
+ */
+class StringArgument constructor(private val name: String, private val description: String = "", private val label: String = name,
+                                     private var value:String = "", private val mustSpecify: Boolean = false) : Connector.Argument {
+
+    override fun name(): String {
+        return name
+    }
+
+    override fun description(): String {
+        return description
+    }
+
+    override fun label(): String {
+        return label
+    }
+
+    override fun mustSpecify(): Boolean {
+        return mustSpecify
+    }
+
+    override fun value(): String {
+        return value
+    }
+
+    override fun setValue(value: String){
+        this.value = value
+    }
+
+    override fun isValid(value: String): Boolean{
+        return true
+    }
+    override fun toString(): String {
+        return value
+    }
+
+
+}

--- a/adapter/src/main/kotlin/org/javacs/ktda/jdi/scope/JDIVariable.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/jdi/scope/JDIVariable.kt
@@ -31,7 +31,7 @@ class JDIVariable(
 	}
 	
 	private fun arrayElementsOf(jdiValue: ArrayReference): List<VariableTreeNode> = jdiValue.values
-		.mapIndexed { i, it -> JDIVariable(i.toString(), it) }
+	    .mapIndexed { i, it -> JDIVariable(i.toString(), it) }
 		
 	private fun fieldsOf(jdiValue: ObjectReference, jdiType: ReferenceType) = jdiType.allFields()
 		.map { JDIVariable(it.name(), jdiValue.getValue(it), jdiType) }

--- a/adapter/src/main/resources/META-INF/services/com.sun.jdi.connect.Connector
+++ b/adapter/src/main/resources/META-INF/services/com.sun.jdi.connect.Connector
@@ -1,0 +1,1 @@
+org.javacs.ktda.jdi.launch.KDACommandLineLauncher

--- a/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
@@ -19,7 +19,7 @@ abstract class DebugAdapterTestFixture(
     private val mainClass: String,
     private val vmArguments: String = "",
     private val cwd: String = "",
-    private val envs: Collection<String> = listOf()
+    private val envs: Map<String, String> = mapOf()
 ) : IDebugProtocolClient {
     val absoluteWorkspaceRoot: Path = Paths.get(DebugAdapterTestFixture::class.java.getResource("/Anchor.txt").toURI()).parent.resolve(relativeWorkspaceRoot)
     lateinit var debugAdapter: KotlinDebugAdapter

--- a/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
@@ -17,7 +17,9 @@ import org.hamcrest.Matchers.equalTo
 abstract class DebugAdapterTestFixture(
     relativeWorkspaceRoot: String,
     private val mainClass: String,
-    private val vmArguments: String = ""
+    private val vmArguments: String = "",
+    private val cwd: String = "",
+    private val envs: Collection<String> = listOf()
 ) : IDebugProtocolClient {
     val absoluteWorkspaceRoot: Path = Paths.get(DebugAdapterTestFixture::class.java.getResource("/Anchor.txt").toURI()).parent.resolve(relativeWorkspaceRoot)
     lateinit var debugAdapter: KotlinDebugAdapter
@@ -60,7 +62,9 @@ abstract class DebugAdapterTestFixture(
         debugAdapter.launch(mapOf(
             "projectRoot" to absoluteWorkspaceRoot.toString(),
             "mainClass" to mainClass,
-            "vmArguments" to vmArguments
+            "vmArguments" to vmArguments,
+            "cwd" to cwd,
+            "envs" to envs
         )).join()
         println("Launched")
     }

--- a/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/DebugAdapterTestFixture.kt
@@ -64,7 +64,7 @@ abstract class DebugAdapterTestFixture(
             "mainClass" to mainClass,
             "vmArguments" to vmArguments,
             "cwd" to cwd,
-            "envs" to envs
+            "env" to envs
         )).join()
         println("Launched")
     }

--- a/adapter/src/test/kotlin/org/javacs/ktda/SampleWorkspaceWithCustomConfigTest.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/SampleWorkspaceWithCustomConfigTest.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.CountDownLatch
  */
 class SampleWorkspaceWithCustomConfigTest : DebugAdapterTestFixture(
         "sample-workspace", "sample.workspace.AppKt",
-        vmArguments = "-Dfoo=bar", cwd = "/tmp", envs = listOf("MSG=hello")) {
+        vmArguments = "-Dfoo=bar", cwd = "/tmp", envs = mapOf("MSG" to "hello")) {
     private val latch = CountDownLatch(1)
     private var asyncException: Throwable? = null
 

--- a/adapter/src/test/kotlin/org/javacs/ktda/SampleWorkspaceWithCustomConfigTest.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/SampleWorkspaceWithCustomConfigTest.kt
@@ -8,12 +8,9 @@ import org.eclipse.lsp4j.debug.StackFrame
 import org.eclipse.lsp4j.debug.StackTraceArguments
 import org.eclipse.lsp4j.debug.StoppedEventArguments
 import org.eclipse.lsp4j.debug.VariablesArguments
+import org.hamcrest.Matchers.*
 import org.junit.Assert.assertThat
 import org.junit.Test
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.hasItem
-import org.hamcrest.Matchers.nullValue
-import org.hamcrest.Matchers.not
 import org.javacs.kt.LOG
 import java.util.concurrent.CountDownLatch
 
@@ -21,7 +18,9 @@ import java.util.concurrent.CountDownLatch
  * Tests a very basic debugging scenario
  * using a sample application.
  */
-class SampleWorkspaceTest : DebugAdapterTestFixture("sample-workspace", "sample.workspace.AppKt") {
+class SampleWorkspaceWithCustomConfigTest : DebugAdapterTestFixture(
+        "sample-workspace", "sample.workspace.AppKt",
+        vmArguments = "-Dfoo=bar", cwd = "/tmp", envs = listOf("MSG=hello")) {
     private val latch = CountDownLatch(1)
     private var asyncException: Throwable? = null
 
@@ -81,8 +80,9 @@ class SampleWorkspaceTest : DebugAdapterTestFixture("sample-workspace", "sample.
             }
 
             assertThat(memberMap["member"], equalTo(""""test""""))
-            assertThat(memberMap["foo"], equalTo("null"))
-            assertThat(memberMap["cwd"]?.trim('"'), equalTo(absoluteWorkspaceRoot.toString()))
+            assertThat(memberMap["foo"], equalTo(""""bar""""))
+            assertThat(memberMap["cwd"]?.trim('"'), containsString("/tmp"))
+            assertThat(memberMap["msg"], equalTo(""""hello""""))
 
         } catch (e: Throwable) {
             asyncException = e

--- a/adapter/src/test/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncherTest.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncherTest.kt
@@ -1,12 +1,8 @@
 package org.javacs.ktda.jdi.launch
 
-import com.sun.jdi.connect.Connector
 import org.hamcrest.Matchers.*
-import org.javacs.ktda.DebugAdapterTestFixture
 import org.junit.Assert.assertThat
 import org.junit.Test
-import java.nio.file.Path
-import java.nio.file.Paths
 
 class KDACommandLineLauncherTest {
 

--- a/adapter/src/test/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncherTest.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncherTest.kt
@@ -1,0 +1,29 @@
+package org.javacs.ktda.jdi.launch
+
+import com.sun.jdi.connect.Connector
+import org.hamcrest.Matchers.*
+import org.javacs.ktda.DebugAdapterTestFixture
+import org.junit.Assert.assertThat
+import org.junit.Test
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class KDACommandLineLauncherTest {
+
+    @Test
+    fun `defaultArguments should include cwd, envs, suspend`() {
+
+        val connector = KDACommandLineLauncher()
+
+        val args = connector.defaultArguments()
+
+        assertThat(args.size, greaterThanOrEqualTo(2))
+
+        assertThat(args["cwd"], notNullValue())
+        assertThat(args["envs"], notNullValue())
+        //suspend should default to true
+        assertThat(args["suspend"]?.value(), equalTo("true"))
+
+    }
+
+}

--- a/adapter/src/test/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncherTest.kt
+++ b/adapter/src/test/kotlin/org/javacs/ktda/jdi/launch/KDACommandLineLauncherTest.kt
@@ -16,7 +16,7 @@ class KDACommandLineLauncherTest {
         assertThat(args.size, greaterThanOrEqualTo(2))
 
         assertThat(args["cwd"], notNullValue())
-        assertThat(args["envs"], notNullValue())
+        assertThat(args["env"], notNullValue())
         //suspend should default to true
         assertThat(args["suspend"]?.value(), equalTo("true"))
 

--- a/adapter/src/test/resources/sample-workspace/src/main/kotlin/sample/workspace/App.kt
+++ b/adapter/src/test/resources/sample-workspace/src/main/kotlin/sample/workspace/App.kt
@@ -1,7 +1,10 @@
 package sample.workspace
 
 class App {
-    private val member: String = System.getProperty("test")
+    private val member: String = "test"
+    private val foo: String? = System.getProperty("foo")
+    private val cwd: String = System.getProperty("user.dir")
+    private val msg: String? = System.getenv("MSG")
     val greeting: String
         get() {
             val local: Int = 123


### PR DESCRIPTION
Shameless copy of #45 (Huge thanks to @thunderz99 !)

Code is updated with latest `main`, is tiny bit cleaner and contains no external dependencies compared to original by thunderz99. 

One noticeable change is `envs` is renamed as `env` to comply with other debug extensions.

Also, added support for `envFile`. Empty lines, and lines starting with `#` are ignored. 
Contents of `env` takes precedence over `envFile`. 


