### PR TITLE
use runtimeClasspath during classpath resolution

### DIFF
--- a/adapter/src/main/kotlin/org/javacs/ktda/classpath/DebugClassPathResolver.kt
+++ b/adapter/src/main/kotlin/org/javacs/ktda/classpath/DebugClassPathResolver.kt
@@ -2,9 +2,12 @@ package org.javacs.ktda.classpath
 
 import org.javacs.kt.classpath.ClassPathResolver
 import org.javacs.kt.classpath.defaultClassPathResolver
+import org.javacs.kt.classpath.ResolverOptions
 import org.javacs.kt.classpath.plus
 import org.javacs.kt.classpath.joined
 import java.nio.file.Path
 
+val options = ResolverOptions(useCompileClasspath = false)
+
 fun debugClassPathResolver(workspaceRoots: Collection<Path>): ClassPathResolver =
-	defaultClassPathResolver(workspaceRoots) + workspaceRoots.map { ProjectClassesResolver(it) }.joined
+	defaultClassPathResolver(workspaceRoots, resolverOptions = options) + workspaceRoots.map { ProjectClassesResolver(it) }.joined


### PR DESCRIPTION
depends on https://github.com/fwcd/kotlin-language-server/pull/590
should help with https://github.com/fwcd/kotlin-debug-adapter/issues/91